### PR TITLE
docs: document data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,45 @@ mini_llm/
 ├── experiments/
 └── README.md
 ```
+
+## Data Pipeline
+
+The project includes a pipeline for collecting and preparing the training data. It runs in three stages:
+
+1. **Fetch articles**
+
+   Download raw reference material from the web and store it as JSON Lines:
+   ```bash
+   python src/data_pipeline.py fetch --output data/raw/articles.jsonl
+   ```
+
+2. **Generate Q&A pairs**
+
+   Turn the articles into question/answer examples:
+   ```bash
+   python src/data_pipeline.py generate --input data/raw/articles.jsonl --output data/processed/qa_pairs.jsonl
+   ```
+
+3. **Create dataset splits**
+
+   Produce train, validation, and test splits:
+   ```bash
+   python src/data_pipeline.py split --input data/processed/qa_pairs.jsonl --output-dir data/splits --train-size 0.8 --val-size 0.1 --test-size 0.1
+   ```
+
+## Data Directory
+
+```
+data/
+├── raw/
+│   └── articles.jsonl        # Raw articles; one JSON object per line
+├── processed/
+│   └── qa_pairs.jsonl        # Generated question/answer pairs
+└── splits/
+    ├── train.jsonl          # Training set (JSONL)
+    ├── val.jsonl            # Validation set (JSONL)
+    └── test.jsonl           # Test set (JSONL)
+```
+
+All files in `data/` use the [JSON Lines](https://jsonlines.org/) format.
+


### PR DESCRIPTION
## Summary
- add detailed usage instructions for `src/data_pipeline.py` to README
- describe dataset directory layout and JSONL file formats

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e16fba4c8326b45a0e2de7ed0e03