### PR TITLE
Add configurable tokenizer with special tokens

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -5,7 +5,7 @@ import argparse
 import torch
 
 from .model import MiniLLM
-from .tokenizer import SimpleTokenizer
+from .tokenizer import Tokenizer
 
 
 def parse_args() -> argparse.Namespace:
@@ -15,8 +15,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     _ = parse_args()
-    tokenizer = SimpleTokenizer()
-    tokenizer.build_vocab(["hello world"])
+    tokenizer = Tokenizer()
+    tokenizer.fit(["hello world"])
     model = MiniLLM(vocab_size=len(tokenizer.token_to_id))
     ids = torch.tensor([tokenizer.encode("hello world")])
     with torch.no_grad():

--- a/src/tokenizer.py
+++ b/src/tokenizer.py
@@ -1,32 +1,106 @@
-"""Simple tokenizer utility for MiniLLM.
+"""Tokenizer utility for MiniLLM.
 
-This tokenizer performs basic whitespace tokenization and mapping
-between tokens and integer IDs. It is intentionally minimal and
-serves as a starting point for experimentation.
+This module provides a minimal whitespace tokenizer with a small
+vocabulary builder. It supports adding special tokens required for the
+MiniLLM experiments and exposes ``fit``, ``encode`` and ``decode``
+methods.
 """
 
-from typing import List
+from collections import Counter
+from typing import Iterable, List
 
-class SimpleTokenizer:
-    """Tokenizes text by whitespace and maintains a vocabulary."""
+
+class Tokenizer:
+    """Whitespace tokenizer with a simple frequency-based vocabulary.
+
+    The tokenizer builds a vocabulary from provided texts and always
+    reserves IDs ``0-3`` for the special tokens ``<PAD>``, ``<BOS>``,
+    ``<EOS>`` and ``<UNK>`` respectively.
+    """
+
+    pad_token: str = "<PAD>"
+    bos_token: str = "<BOS>"
+    eos_token: str = "<EOS>"
+    unk_token: str = "<UNK>"
 
     def __init__(self) -> None:
+        self.special_tokens = [
+            self.pad_token,
+            self.bos_token,
+            self.eos_token,
+            self.unk_token,
+        ]
+
+        # Fixed IDs for the special tokens
+        self.pad_id, self.bos_id, self.eos_id, self.unk_id = range(4)
+
+        # Vocabulary mappings
         self.token_to_id = {}
         self.id_to_token = {}
 
-    def build_vocab(self, texts: List[str]) -> None:
-        """Build a vocabulary from an iterable of texts."""
+    # ------------------------------------------------------------------
+    def fit(self, texts: Iterable[str], vocab_size: int = 8000) -> None:
+        """Build vocabulary from ``texts``.
+
+        The vocabulary is built by simple whitespace tokenisation. Tokens
+        are counted and the most frequent ones are kept until the desired
+        ``vocab_size`` (including special tokens) is reached.
+        """
+
+        # Reset vocab and initialise with special tokens
+        self.token_to_id = {tok: i for i, tok in enumerate(self.special_tokens)}
+        self.id_to_token = {i: tok for i, tok in enumerate(self.special_tokens)}
+
+        counter: Counter[str] = Counter()
         for text in texts:
-            for token in text.split():
-                if token not in self.token_to_id:
-                    idx = len(self.token_to_id)
-                    self.token_to_id[token] = idx
-                    self.id_to_token[idx] = token
+            counter.update(text.split())
 
-    def encode(self, text: str) -> List[int]:
-        """Convert a string into a list of token IDs."""
-        return [self.token_to_id.get(tok, -1) for tok in text.split()]
+        # Remove any occurrence of special tokens from the counts
+        for tok in self.special_tokens:
+            counter.pop(tok, None)
 
-    def decode(self, ids: List[int]) -> str:
-        """Convert a list of token IDs back into a string."""
-        return " ".join(self.id_to_token.get(i, "<unk>") for i in ids)
+        limit = vocab_size - len(self.special_tokens)
+        for token, _ in counter.most_common(limit):
+            idx = len(self.token_to_id)
+            self.token_to_id[token] = idx
+            self.id_to_token[idx] = token
+
+    # ------------------------------------------------------------------
+    def encode(
+        self, text: str, add_bos: bool = False, add_eos: bool = False
+    ) -> List[int]:
+        """Convert ``text`` into a list of token IDs.
+
+        Unknown tokens are mapped to ``<UNK>``. ``<BOS>`` and ``<EOS>``
+        tokens can be optionally added to the beginning and end of the
+        sequence.
+        """
+
+        ids = [
+            self.token_to_id.get(tok, self.unk_id) for tok in text.split()
+        ]
+        if add_bos:
+            ids.insert(0, self.bos_id)
+        if add_eos:
+            ids.append(self.eos_id)
+        return ids
+
+    # ------------------------------------------------------------------
+    def decode(self, ids: List[int], skip_special_tokens: bool = False) -> str:
+        """Convert a list of IDs back into a string.
+
+        Special tokens can be optionally removed from the returned text
+        by setting ``skip_special_tokens`` to ``True``.
+        """
+
+        tokens: List[str] = []
+        for idx in ids:
+            token = self.id_to_token.get(idx, self.unk_token)
+            if skip_special_tokens and token in self.special_tokens:
+                continue
+            tokens.append(token)
+        return " ".join(tokens)
+
+
+__all__ = ["Tokenizer"]
+

--- a/src/train.py
+++ b/src/train.py
@@ -8,7 +8,7 @@ import torch
 from torch import nn, optim
 
 from .model import MiniLLM
-from .tokenizer import SimpleTokenizer
+from .tokenizer import Tokenizer
 
 
 def parse_args() -> argparse.Namespace:
@@ -19,8 +19,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    tokenizer = SimpleTokenizer()
-    tokenizer.build_vocab(["hello world"])
+    tokenizer = Tokenizer()
+    tokenizer.fit(["hello world"])
 
     model = MiniLLM(vocab_size=len(tokenizer.token_to_id))
     criterion = nn.CrossEntropyLoss()


### PR DESCRIPTION
## Summary
- replace SimpleTokenizer with new Tokenizer class supporting fit, encode and decode
- build vocabulary with reserved special tokens and optional BOS/EOS handling
- update training and evaluation scripts to use the new tokenizer

## Testing
- `python -m pytest`
- `python -m src.train --epochs 1`
- `python -m src.eval`


------
https://chatgpt.com/codex/tasks/task_e_68a5ef6d9cd48326af4270d50847e7d1