### PR TITLE
Introduce embedding module and dimension parameters

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -32,7 +32,7 @@ def main() -> None:
     else:
         raise FileNotFoundError(f"Vocabulary file not found at {VOCAB_PATH}")
 
-    model = MiniLLM(vocab_size=len(tokenizer.token_to_id))
+    model = MiniLLM(vocab_size=len(tokenizer.token_to_id), emb_dim=32)
 
     encoded = tokenizer.encode(args.text, add_bos=True, add_eos=True)
     ids = torch.tensor([encoded], dtype=torch.long)

--- a/src/model.py
+++ b/src/model.py
@@ -1,16 +1,27 @@
 """Neural network model definition for MiniLLM."""
 
-from typing import Tuple
 import torch
 from torch import nn
+
+
+class Embedding(nn.Module):
+    """Lightweight wrapper around :class:`nn.Embedding`."""
+
+    def __init__(self, vocab_size: int, emb_dim: int) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, emb_dim)
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        return self.embedding(ids)
+
 
 class MiniLLM(nn.Module):
     """A tiny language model built with PyTorch."""
 
-    def __init__(self, vocab_size: int, hidden_size: int = 32) -> None:
+    def __init__(self, vocab_size: int, emb_dim: int) -> None:
         super().__init__()
-        self.embedding = nn.Embedding(vocab_size, hidden_size)
-        self.linear = nn.Linear(hidden_size, vocab_size)
+        self.embedding = Embedding(vocab_size, emb_dim)
+        self.linear = nn.Linear(emb_dim, vocab_size)
 
     def forward(self, ids: torch.Tensor) -> torch.Tensor:
         """Forward pass that embeds token IDs and predicts logits."""

--- a/src/train.py
+++ b/src/train.py
@@ -80,7 +80,7 @@ def main() -> None:
 
     targets = inputs.clone()
 
-    model = MiniLLM(vocab_size=len(tokenizer.token_to_id))
+    model = MiniLLM(vocab_size=len(tokenizer.token_to_id), emb_dim=32)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters())
 


### PR DESCRIPTION
## Summary
- Add `Embedding` wrapper using `nn.Embedding` in `model.py`
- Update `MiniLLM` to accept `vocab_size` and `emb_dim` and consume embeddings in forward pass
- Pass `emb_dim` when constructing `MiniLLM` in training and evaluation scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60031fe18832699c136c0bc2490a7