### PR TITLE
Add positional encoding and model configuration

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for MiniLLM."""
+
+from .model import MiniLLM, ModelConfig
+
+__all__ = ["MiniLLM", "ModelConfig"]
+

--- a/src/eval.py
+++ b/src/eval.py
@@ -6,7 +6,7 @@ import argparse
 from pathlib import Path
 import torch
 
-from .model import MiniLLM
+from .model import MiniLLM, ModelConfig
 from .tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
@@ -32,10 +32,16 @@ def main() -> None:
     else:
         raise FileNotFoundError(f"Vocabulary file not found at {VOCAB_PATH}")
 
-    model = MiniLLM(vocab_size=len(tokenizer.token_to_id), emb_dim=32)
-
     encoded = tokenizer.encode(args.text, add_bos=True, add_eos=True)
     ids = torch.tensor([encoded], dtype=torch.long)
+
+    config = ModelConfig(
+        vocab_size=len(tokenizer.token_to_id),
+        emb_dim=32,
+        max_seq_len=len(encoded),
+        learnable_pos=False,
+    )
+    model = MiniLLM(config)
 
     with torch.no_grad():
         logits = model(ids)

--- a/src/model.py
+++ b/src/model.py
@@ -1,5 +1,10 @@
 """Neural network model definition for MiniLLM."""
 
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
 import torch
 from torch import nn
 
@@ -15,15 +20,87 @@ class Embedding(nn.Module):
         return self.embedding(ids)
 
 
+class PositionalEncoding(nn.Module):
+    """Add positional information to token embeddings.
+
+    Supports either sinusoidal positional encodings or learnable position
+    embeddings via :class:`nn.Parameter`.
+    """
+
+    def __init__(
+        self, emb_dim: int, max_seq_len: int, learnable: bool = False
+    ) -> None:
+        super().__init__()
+        self.emb_dim = emb_dim
+        self.max_seq_len = max_seq_len
+        self.learnable = learnable
+
+        if learnable:
+            # ``nn.Parameter`` so positions are learned during training.
+            self.pos_embedding = nn.Parameter(
+                torch.zeros(1, max_seq_len, emb_dim)
+            )
+        else:
+            # Pre-compute sinusoidal embeddings and store as a buffer so it is
+            # moved correctly across devices but not updated during training.
+            position = torch.arange(max_seq_len, dtype=torch.float).unsqueeze(1)
+            div_term = torch.exp(
+                torch.arange(0, emb_dim, 2).float()
+                * (-math.log(10000.0) / emb_dim)
+            )
+            pe = torch.zeros(max_seq_len, emb_dim)
+            pe[:, 0::2] = torch.sin(position * div_term)
+            pe[:, 1::2] = torch.cos(position * div_term)
+            self.register_buffer("pos_embedding", pe.unsqueeze(0), persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Add positional encodings to ``x``.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input tensor of shape ``(batch_size, seq_len, emb_dim)``.
+        """
+
+        seq_len = x.size(1)
+        if seq_len > self.max_seq_len:
+            raise ValueError(
+                f"Sequence length {seq_len} exceeds maximum {self.max_seq_len}"
+            )
+        return x + self.pos_embedding[:, :seq_len, :]
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for :class:`MiniLLM`."""
+
+    vocab_size: int
+    emb_dim: int
+    max_seq_len: int = 512
+    learnable_pos: bool = False
+
+
 class MiniLLM(nn.Module):
     """A tiny language model built with PyTorch."""
 
-    def __init__(self, vocab_size: int, emb_dim: int) -> None:
+    def __init__(self, config: ModelConfig) -> None:
         super().__init__()
-        self.embedding = Embedding(vocab_size, emb_dim)
-        self.linear = nn.Linear(emb_dim, vocab_size)
+        self.config = config
+        self.embedding = Embedding(config.vocab_size, config.emb_dim)
+        self.pos_encoding = PositionalEncoding(
+            config.emb_dim, config.max_seq_len, config.learnable_pos
+        )
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.emb_dim, nhead=4, batch_first=True
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=1)
+        self.linear = nn.Linear(config.emb_dim, config.vocab_size)
 
     def forward(self, ids: torch.Tensor) -> torch.Tensor:
         """Forward pass that embeds token IDs and predicts logits."""
+
         x = self.embedding(ids)
+        x = self.pos_encoding(x)
+        x = self.transformer(x)
         return self.linear(x)
+

--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from typing import List
 import torch
 from torch import nn, optim
 
-from .model import MiniLLM
+from .model import MiniLLM, ModelConfig
 from .tokenizer import Tokenizer
 
 
@@ -80,7 +80,13 @@ def main() -> None:
 
     targets = inputs.clone()
 
-    model = MiniLLM(vocab_size=len(tokenizer.token_to_id), emb_dim=32)
+    config = ModelConfig(
+        vocab_size=len(tokenizer.token_to_id),
+        emb_dim=32,
+        max_seq_len=max_len,
+        learnable_pos=False,
+    )
+    model = MiniLLM(config)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters())
 


### PR DESCRIPTION
## Summary
- implement sinusoidal or learnable `PositionalEncoding`
- introduce `ModelConfig` with `max_seq_len` and `learnable_pos` and apply positional encoding before transformer layer
- update training and evaluation scripts to use new configuration

## Testing
- `python -m py_compile src/model.py src/train.py src/eval.py src/__init__.py && echo py_compile_success`
- `python -m src.train --epochs 1`
- `python -m src.eval "hello"`


------
https://chatgpt.com/codex/tasks/task_e_68a60300cc688326855d08df189cab2f