### PR TITLE
Add self-attention module

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -38,6 +38,7 @@ def main() -> None:
     config = ModelConfig(
         vocab_size=len(tokenizer.token_to_id),
         emb_dim=32,
+        num_heads=4,
         max_seq_len=len(encoded),
         learnable_pos=False,
     )

--- a/src/train.py
+++ b/src/train.py
@@ -83,6 +83,7 @@ def main() -> None:
     config = ModelConfig(
         vocab_size=len(tokenizer.token_to_id),
         emb_dim=32,
+        num_heads=4,
         max_seq_len=max_len,
         learnable_pos=False,
     )


### PR DESCRIPTION
## Summary
- Implement custom `SelfAttention` layer with configurable heads, embedding dimension, and dropout
- Update model configuration and MiniLLM to use new self-attention
- Adjust training and evaluation scripts for head parameter

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a606a2fa8c8326a4fc7e9e0be7d5f4