### PR TITLE
Add feed-forward network after attention

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -41,6 +41,7 @@ def main() -> None:
         num_heads=4,
         max_seq_len=len(encoded),
         learnable_pos=False,
+        ffn_dim=128,
     )
     model = MiniLLM(config)
 

--- a/src/train.py
+++ b/src/train.py
@@ -86,6 +86,7 @@ def main() -> None:
         num_heads=4,
         max_seq_len=max_len,
         learnable_pos=False,
+        ffn_dim=128,
     )
     model = MiniLLM(config)
     criterion = nn.CrossEntropyLoss()


### PR DESCRIPTION
## Summary
- add configurable FFN block with GELU activation and dropout after self-attention
- expose `ffn_dim` in `ModelConfig`
- update training and eval scripts with example `ffn_dim`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60d2583fc832695cfdb6499302ec5