### PR TITLE
Add configurable Transformer blocks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for MiniLLM."""
 
-from .model import MiniLLM, ModelConfig
+from .model import MiniTransformer, ModelConfig
 
-__all__ = ["MiniLLM", "ModelConfig"]
+__all__ = ["MiniTransformer", "ModelConfig"]
 

--- a/src/eval.py
+++ b/src/eval.py
@@ -6,7 +6,7 @@ import argparse
 from pathlib import Path
 import torch
 
-from .model import MiniLLM, ModelConfig
+from .model import MiniTransformer, ModelConfig
 from .tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
@@ -43,7 +43,7 @@ def main() -> None:
         learnable_pos=False,
         ffn_dim=128,
     )
-    model = MiniLLM(config)
+    model = MiniTransformer(config)
 
     with torch.no_grad():
         logits = model(ids)

--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from typing import List
 import torch
 from torch import nn, optim
 
-from .model import MiniLLM, ModelConfig
+from .model import MiniTransformer, ModelConfig
 from .tokenizer import Tokenizer
 
 
@@ -88,7 +88,7 @@ def main() -> None:
         learnable_pos=False,
         ffn_dim=128,
     )
-    model = MiniLLM(config)
+    model = MiniTransformer(config)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters())
 


### PR DESCRIPTION
## Summary
- build reusable `TransformerBlock` with attention and feed-forward layers
- stack multiple blocks via new `MiniTransformer` using configurable `num_layers`
- expose `MiniTransformer` from package and update training/eval scripts

## Testing
- `pytest`
- `python -m py_compile src/model.py src/__init__.py src/train.py src/eval.py`


------
https://chatgpt.com/codex/tasks/task_e_68a61613bf8c832686a82ed576ba3aa8