### PR TITLE
Add MiniLLM tests for weight tying and positional encoding

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -6,7 +6,7 @@ import argparse
 from pathlib import Path
 import torch
 
-from .model import MiniLLM
+from .model import MiniLLM, ModelConfig
 from .tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
@@ -32,7 +32,8 @@ def main() -> None:
     else:
         raise FileNotFoundError(f"Vocabulary file not found at {VOCAB_PATH}")
 
-    model = MiniLLM(vocab_size=len(tokenizer.token_to_id))
+    config = ModelConfig(vocab_size=len(tokenizer.token_to_id))
+    model = MiniLLM(config)
 
     encoded = tokenizer.encode(args.text, add_bos=True, add_eos=True)
     ids = torch.tensor([encoded], dtype=torch.long)

--- a/src/model.py
+++ b/src/model.py
@@ -7,6 +7,8 @@ from typing import Optional
 import torch
 from torch import nn
 
+__all__ = ["ModelConfig", "MiniLLM"]
+
 
 @dataclass
 class ModelConfig:

--- a/src/model.py
+++ b/src/model.py
@@ -1,18 +1,58 @@
 """Neural network model definition for MiniLLM."""
 
-from typing import Tuple
+from dataclasses import dataclass
+import math
+from typing import Optional
+
 import torch
 from torch import nn
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for :class:`MiniLLM`."""
+
+    vocab_size: int
+    hidden_size: int = 32
+    max_seq_len: int = 512
+    tie_weights: bool = False
+    positional_encoding: Optional[str] = None  # ``"sinusoidal"`` or ``None``
+
 
 class MiniLLM(nn.Module):
     """A tiny language model built with PyTorch."""
 
-    def __init__(self, vocab_size: int, hidden_size: int = 32) -> None:
+    def __init__(self, config: ModelConfig) -> None:
         super().__init__()
-        self.embedding = nn.Embedding(vocab_size, hidden_size)
-        self.linear = nn.Linear(hidden_size, vocab_size)
+        self.config = config
+
+        self.embedding = nn.Embedding(config.vocab_size, config.hidden_size)
+
+        if config.positional_encoding == "sinusoidal":
+            pe = self._build_sinusoidal_pe(config.max_seq_len, config.hidden_size)
+            self.register_buffer("positional_encoding", pe)
+        else:
+            self.positional_encoding = None
+
+        self.linear = nn.Linear(
+            config.hidden_size, config.vocab_size, bias=False
+        )
+        if config.tie_weights:
+            self.linear.weight = self.embedding.weight
+
+    @staticmethod
+    def _build_sinusoidal_pe(max_len: int, dim: int) -> torch.Tensor:
+        """Create sinusoidal positional encodings."""
+        pe = torch.zeros(max_len, dim)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, dim, 2).float() * (-math.log(10000.0) / dim))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        return pe
 
     def forward(self, ids: torch.Tensor) -> torch.Tensor:
         """Forward pass that embeds token IDs and predicts logits."""
         x = self.embedding(ids)
+        if self.positional_encoding is not None:
+            x = x + self.positional_encoding[: x.size(1)]
         return self.linear(x)

--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from typing import List
 import torch
 from torch import nn, optim
 
-from .model import MiniLLM
+from .model import MiniLLM, ModelConfig
 from .tokenizer import Tokenizer
 
 
@@ -80,7 +80,8 @@ def main() -> None:
 
     targets = inputs.clone()
 
-    model = MiniLLM(vocab_size=len(tokenizer.token_to_id))
+    config = ModelConfig(vocab_size=len(tokenizer.token_to_id))
+    model = MiniLLM(config)
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(model.parameters())
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import torch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from model import MiniLLM, ModelConfig
+
+
+def test_forward_shape():
+    config = ModelConfig(vocab_size=10, hidden_size=8)
+    model = MiniLLM(config)
+    ids = torch.randint(0, config.vocab_size, (2, 4))
+    out = model(ids)
+    assert out.shape == (2, 4, config.vocab_size)
+
+
+def test_parameter_tying():
+    config = ModelConfig(vocab_size=10, hidden_size=8, tie_weights=True)
+    model = MiniLLM(config)
+    assert model.linear.weight.data_ptr() == model.embedding.weight.data_ptr()
+    ids = torch.randint(0, config.vocab_size, (1, 3))
+    out = model(ids)
+    assert out.shape == (1, 3, config.vocab_size)
+
+
+def test_positional_encoding_options():
+    torch.manual_seed(0)
+    config_none = ModelConfig(vocab_size=10, hidden_size=8, max_seq_len=4, positional_encoding=None)
+    model_none = MiniLLM(config_none)
+    ids = torch.randint(0, config_none.vocab_size, (2, 4))
+    out_none = model_none(ids)
+
+    torch.manual_seed(0)
+    config_sin = ModelConfig(vocab_size=10, hidden_size=8, max_seq_len=4, positional_encoding="sinusoidal")
+    model_sin = MiniLLM(config_sin)
+    out_sin = model_sin(ids)
+
+    assert out_sin.shape == out_none.shape == (2, 4, config_none.vocab_size)
+    assert model_none.positional_encoding is None
+    assert model_sin.positional_encoding is not None
+    assert not torch.allclose(out_sin, out_none)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,7 +17,7 @@ def test_forward_shape():
 def test_parameter_tying():
     config = ModelConfig(vocab_size=10, hidden_size=8, tie_weights=True)
     model = MiniLLM(config)
-    assert model.linear.weight.data_ptr() == model.embedding.weight.data_ptr()
+    assert model.linear.weight is model.embedding.weight
     ids = torch.randint(0, config.vocab_size, (1, 3))
     out = model(ids)
     assert out.shape == (1, 3, config.vocab_size)


### PR DESCRIPTION
## Summary
- add `ModelConfig` and support for weight tying and optional sinusoidal positional encodings in `MiniLLM`
- add tests ensuring correct output shape, parameter tying, and positional encoding behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a60029f7cc832693ce69febda30ed0