### PR TITLE
Use PyTorch checkpoints for training output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ print(f"{params/1e6:.2f}M parameters (~{params*4/1e6:.2f} MB)")
 Running the code prints approximately `3.35M parameters (~13 MB)` for the
 configuration above.
 
+## Training and Checkpoints
+
+Train the model with:
+
+```bash
+python src/train.py --run-dir experiments/run
+```
+
+This writes the trained weights to `experiments/run/model.pt`. The same file can
+be used for text generation or evaluation:
+
+```bash
+# Generate text
+python src/generate.py --checkpoint experiments/run/model.pt "your prompt"
+
+# Evaluate a question
+python src/eval.py --checkpoint experiments/run/model.pt --question "your question"
+```
+
 ## Weight Initialization
 
 All linear layers in MiniLLM are initialized with Xavier initialization and

--- a/src/eval.py
+++ b/src/eval.py
@@ -11,7 +11,7 @@ from .model import MiniTransformer, ModelConfig
 from .tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
-MODEL_PATH = Path("data/model.pt")
+MODEL_PATH = Path("experiments/run/model.pt")
 
 
 def parse_args() -> argparse.Namespace:

--- a/src/generate.py
+++ b/src/generate.py
@@ -17,7 +17,7 @@ from .tokenizer import Tokenizer
 
 
 VOCAB_PATH = Path("data/vocab.json")
-MODEL_PATH = Path("data/model.pt")
+MODEL_PATH = Path("experiments/run/model.pt")
 
 
 def parse_args() -> argparse.Namespace:

--- a/src/train.py
+++ b/src/train.py
@@ -162,10 +162,8 @@ def main() -> None:
         val_loss /= max(1, len(val_loader))
 
         generated = generate_answer(model, tokenizer, sample_question, max_seq_len)
-        # Save model parameters as JSON to avoid binary .pt files
-        state_dict = {k: v.tolist() for k, v in model.state_dict().items()}
-        with (run_dir / f"model_epoch{epoch}.json").open("w", encoding="utf-8") as f:
-            json.dump(state_dict, f)
+        # Save model parameters for later use
+        torch.save(model.state_dict(), run_dir / "model.pt")
 
         entry = {
             "epoch": epoch,


### PR DESCRIPTION
## Summary
- Save training checkpoints as binary `model.pt` using `torch.save`
- Load checkpoint weights with `torch.load` in generation and evaluation scripts
- Document training and inference using `.pt` checkpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a639912f8c8326a41804e3f57aa38f