### PR TITLE
Use JSONL format for data splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ data/
 ├── processed/
 │   └── qa_pairs.jsonl        # Generated question/answer pairs
 └── splits/
-    ├── train.jsonl          # Training set (JSONL)
-    ├── val.jsonl            # Validation set (JSONL)
-    └── test.jsonl           # Test set (JSONL)
+    ├── train.jsonl          # Training set (one JSON object per line)
+    ├── val.jsonl            # Validation set (one JSON object per line)
+    └── test.jsonl           # Test set (one JSON object per line)
 ```
 
 All files in `data/` use the [JSON Lines](https://jsonlines.org/) format.

--- a/data/splits/train.json
+++ b/data/splits/train.json
@@ -1,6 +1,0 @@
-[
-  {"question": "What is the capital of France?", "answer": "Paris is the capital of France."},
-  {"question": "Who wrote Hamlet?", "answer": "Hamlet was written by William Shakespeare."},
-  {"question": "What is the largest planet?", "answer": "Jupiter is the largest planet in our solar system."},
-  {"question": "What do bees produce?", "answer": "Bees produce honey."}
-]

--- a/data/splits/train.jsonl
+++ b/data/splits/train.jsonl
@@ -1,0 +1,4 @@
+{"question": "What is the capital of France?", "answer": "Paris is the capital of France."}
+{"question": "Who wrote Hamlet?", "answer": "Hamlet was written by William Shakespeare."}
+{"question": "What is the largest planet?", "answer": "Jupiter is the largest planet in our solar system."}
+{"question": "What do bees produce?", "answer": "Bees produce honey."}

--- a/data/splits/val.json
+++ b/data/splits/val.json
@@ -1,4 +1,0 @@
-[
-  {"question": "What is the boiling point of water?", "answer": "The boiling point of water is 100 degrees Celsius."},
-  {"question": "What gas do plants breathe in?", "answer": "Plants take in carbon dioxide."}
-]

--- a/data/splits/val.jsonl
+++ b/data/splits/val.jsonl
@@ -1,0 +1,2 @@
+{"question": "What is the boiling point of water?", "answer": "The boiling point of water is 100 degrees Celsius."}
+{"question": "What gas do plants breathe in?", "answer": "Plants take in carbon dioxide."}

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -38,6 +38,10 @@ def save_dataset(pairs: List[Dict[str, str]], path: Path) -> None:
     if final_path.suffix == ".json":
         with final_path.open("w", encoding="utf-8") as f:
             json.dump(items, f, ensure_ascii=False, indent=2)
+    elif final_path.suffix == ".jsonl":
+        with final_path.open("w", encoding="utf-8") as f:
+            for item in items:
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
     elif final_path.suffix == ".csv":
         fieldnames = ["question", "answer"] + (["context"] if has_context else [])
         with final_path.open("w", newline="", encoding="utf-8") as f:
@@ -132,6 +136,10 @@ def save_dataset(pairs: Iterable[Dict[str, str]], path: Path) -> None:
     if path.suffix == ".json":
         with path.open("w", encoding="utf-8") as f:
             json.dump(cleaned, f, ensure_ascii=False, indent=2)
+    elif path.suffix == ".jsonl":
+        with path.open("w", encoding="utf-8") as f:
+            for item in cleaned:
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
     elif path.suffix == ".csv":
         import csv
 
@@ -170,9 +178,9 @@ def split_dataset(
     test_pairs = shuffled[val_end:]
 
     SPLITS_DIR.mkdir(parents=True, exist_ok=True)
-    save_dataset(train_pairs, SPLITS_DIR / "train.json")
-    save_dataset(val_pairs, SPLITS_DIR / "val.json")
-    save_dataset(test_pairs, SPLITS_DIR / "test.json")
+    save_dataset(train_pairs, SPLITS_DIR / "train.jsonl")
+    save_dataset(val_pairs, SPLITS_DIR / "val.jsonl")
+    save_dataset(test_pairs, SPLITS_DIR / "test.jsonl")
 
     return train_pairs, val_pairs, test_pairs
 

--- a/src/train.py
+++ b/src/train.py
@@ -15,16 +15,18 @@ from .model import MiniTransformer, ModelConfig
 from .tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
-TRAIN_PATH = Path("data/splits/train.json")
-VAL_PATH = Path("data/splits/val.json")
+# Data splits are stored in JSON Lines format
+TRAIN_PATH = Path("data/splits/train.jsonl")
+VAL_PATH = Path("data/splits/val.jsonl")
 
 
 class QADataset(Dataset):
     """Dataset of tokenised question–answer pairs."""
 
     def __init__(self, path: Path, tokenizer: Tokenizer, limit: int | None = None) -> None:
+        # Each line in the dataset file is a JSON object with question and answer
         with path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
+            data = [json.loads(line) for line in f if line.strip()]
         if limit is not None:
             data = data[:limit]
         self.pairs = data
@@ -101,7 +103,7 @@ def main() -> None:
     for path in [TRAIN_PATH, VAL_PATH]:
         if path.exists():
             with path.open("r", encoding="utf-8") as f:
-                data = json.load(f)
+                data = [json.loads(line) for line in f if line.strip()]
             texts.extend(f"{d['question']} {d['answer']}".strip() for d in data)
     tokenizer.fit(texts, vocab_size=args.vocab_size)
     VOCAB_PATH.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Convert training and validation splits to `.jsonl`
- Update training and data pipeline code to read and write JSON Lines
- Clarify dataset structure and JSONL usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a30a15f48326a44e4c0088981b98