### PR TITLE
Allow direct execution of train and eval scripts

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 import torch
 
-
-from .model import MiniTransformer, ModelConfig
-from .tokenizer import Tokenizer
+# Allow execution via ``python src/eval.py`` by ensuring the repository root is
+# on ``sys.path`` before importing package modules.
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+from src.model import MiniTransformer, ModelConfig
+from src.tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
 MODEL_PATH = Path("experiments/run/model.pt")
@@ -67,3 +71,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/src/train.py
+++ b/src/train.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import List, Tuple
 
@@ -11,8 +12,13 @@ import torch
 from torch import nn, optim
 from torch.utils.data import DataLoader, Dataset
 
-from .model import MiniTransformer, ModelConfig
-from .tokenizer import Tokenizer
+# The training script can be executed directly (``python src/train.py``) or as a
+# module (``python -m src.train``). Add the repository root to ``sys.path`` when
+# run as a script so that absolute imports remain valid.
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+from src.model import MiniTransformer, ModelConfig
+from src.tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
 # Data splits are stored in JSON Lines format


### PR DESCRIPTION
## Summary
- Permit `train.py` to run as a standalone script by appending the repository root to `sys.path` and using package imports
- Apply the same standalone-execution logic to `eval.py`

## Testing
- `pytest -q`
- `python src/train.py --run-dir experiments/run --epochs 1 --limit 1`


------
https://chatgpt.com/codex/tasks/task_e_68a8fabdafac83268e2db06096d5737d