### PR TITLE
Ensure eval uses correct model configuration

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -4,15 +4,22 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import List, Tuple
+from dataclasses import asdict
 
 import torch
 from torch import nn, optim
 from torch.utils.data import DataLoader, Dataset
 
-from .model import MiniTransformer, ModelConfig
-from .tokenizer import Tokenizer
+# The training script can be executed directly (``python src/train.py``) or as a
+# module (``python -m src.train``). Add the repository root to ``sys.path`` when
+# run as a script so that absolute imports remain valid.
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+from src.model import MiniTransformer, ModelConfig
+from src.tokenizer import Tokenizer
 
 VOCAB_PATH = Path("data/vocab.json")
 # Data splits are stored in JSON Lines format
@@ -130,6 +137,8 @@ def main() -> None:
         num_heads=2,
         ffn_dim=64,
     )
+    with (run_dir / "model_config.json").open("w", encoding="utf-8") as f:
+        json.dump(asdict(config), f, indent=2)
     model = MiniTransformer(config)
 
     criterion = nn.CrossEntropyLoss(ignore_index=tokenizer.pad_id)


### PR DESCRIPTION
## Summary
- save transformer configuration to each run directory
- load run-specific vocab and config in eval to match checkpoint parameters

## Testing
- `pytest -q`
- `python src/train.py --run-dir experiments/test_run --epochs 1 --limit 1`
- `python src/eval.py --checkpoint experiments/test_run/model.pt --question "What is the boiling point of water?"`

------
https://chatgpt.com/codex/tasks/task_e_68a8fabdafac83268e2db06096d5737d