### PR TITLE
fix tofu init s3 backend region

### DIFF
--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -9,6 +9,23 @@ on:
 jobs:
   apply:
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-2
+      TF_STATE_BUCKET: ${{ secrets.TF_STATE_BUCKET }}
+      TF_STATE_KEY: infra/terraform.tfstate
+      TF_VAR_region: ${{ env.AWS_REGION }}
     steps:
       - uses: actions/checkout@v4
-      - run: echo "Apply infrastructure"
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Init and validate infrastructure
+        working-directory: infra
+        run: |
+          tofu init -backend-config="bucket=${TF_STATE_BUCKET}" \
+                    -backend-config="key=${TF_STATE_KEY}" \
+                    -backend-config="region=${AWS_REGION}" \
+                    -input=false
+          tofu validate

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -6,4 +6,5 @@ terraform {
       version = "~> 5.0"
     }
   }
+  backend "s3" {}
 }


### PR DESCRIPTION
## Summary
- configure OpenTofu workflow with explicit AWS region and backend settings
- declare S3 backend in terraform versions file

## Testing
- `tofu init -backend=false` *(fails: could not resolve provider; no network access)*
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb14e91c8326a510b4f0d9180594