### PR TITLE
Refactor data pipeline CLI

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -1,66 +1,18 @@
+"""Utilities for collecting and processing data for MiniLLM.
 
-
-"""Data pipeline utilities for saving datasets."""
-
-from __future__ import annotations
-
-import csv
-import json
-from pathlib import Path
-from typing import Dict, List
-
-
-def save_dataset(pairs: List[Dict[str, str]], path: Path) -> None:
-    """Save question/answer pairs to JSON or CSV.
-
-    The file is written inside ``data/processed`` using the file name from
-    ``path``. Supported formats are JSON (``.json``) and CSV (``.csv``).
-
-    Args:
-        pairs: Sequence of dictionaries with ``question`` and ``answer`` keys and
-            an optional ``context`` key.
-        path: Target file path. Only the file name is used; the directory is
-            always ``data/processed``.
-    """
-    processed_dir = Path("data/processed")
-    processed_dir.mkdir(parents=True, exist_ok=True)
-    final_path = processed_dir / path.name
-
-    items = []
-    has_context = False
-    for pair in pairs:
-        item = {"question": pair["question"], "answer": pair["answer"]}
-        if "context" in pair and pair["context"] is not None:
-            item["context"] = pair["context"]
-            has_context = True
-        items.append(item)
-
-    if final_path.suffix == ".json":
-        with final_path.open("w", encoding="utf-8") as f:
-            json.dump(items, f, ensure_ascii=False, indent=2)
-    elif final_path.suffix == ".jsonl":
-        with final_path.open("w", encoding="utf-8") as f:
-            for item in items:
-                f.write(json.dumps(item, ensure_ascii=False) + "\n")
-    elif final_path.suffix == ".csv":
-        fieldnames = ["question", "answer"] + (["context"] if has_context else [])
-        with final_path.open("w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
-            writer.writeheader()
-            for row in items:
-                writer.writerow(row)
-    else:
-        raise ValueError(f"Unsupported file format: {final_path.suffix}")
-
-"""Utilities for collecting and processing data for MiniLLM."""
+This module powers the command line interface documented in the README.  It
+can fetch short reference articles from Wikipedia, turn them into question and
+answer pairs, and create train/validation/test splits saved as JSON Lines.
+"""
 
 from __future__ import annotations
 
+import argparse
 import json
 import random
 import re
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Sequence, Tuple
 
 import wikipedia
 
@@ -70,27 +22,49 @@ RAW_DIR = Path("data/raw")
 PROCESSED_DIR = Path("data/processed")
 SPLITS_DIR = Path("data/splits")
 
+# A small but diverse set of topics that mirrors the project scope in the
+# README.  Users can override this list via command line flags, but having a
+# sensible default makes ``python src/data_pipeline.py fetch`` work out of the
+# box.
+DEFAULT_TOPICS: Tuple[str, ...] = (
+    "Sun",
+    "Moon",
+    "Mars",
+    "Jupiter",
+    "Human heart",
+    "Human brain",
+    "African elephant",
+    "Honey bee",
+    "Water cycle",
+    "Photosynthesis",
+    "Hurricane",
+    "Plate tectonics",
+)
 
-def fetch_articles(topics: List[str]) -> List[str]:
+
+def fetch_articles(topics: Sequence[str]) -> List[Dict[str, str]]:
     """Fetch short Wikipedia articles for the given topics.
 
     Each article is truncated to the first 300 words and stored under
-    ``data/raw/<topic>.txt``. The collected article texts are returned as a
-    list.
+    ``data/raw/<topic>.txt``.  A JSON compatible representation containing the
+    topic and the truncated article text is returned for further processing.
     """
 
     RAW_DIR.mkdir(parents=True, exist_ok=True)
-    articles: List[str] = []
+    articles: List[Dict[str, str]] = []
     for topic in topics:
         try:
             text = wikipedia.page(topic).content
         except Exception:
-            # Skip topics that cannot be retrieved
+            # Skip topics that cannot be retrieved, e.g. disambiguation pages or
+            # missing entries.
             continue
+
         words = text.split()
         limited = " ".join(words[:300])
-        articles.append(limited)
         save_text(RAW_DIR / f"{topic.replace(' ', '_')}.txt", limited)
+        articles.append({"topic": topic, "content": limited})
+
     return articles
 
 
@@ -107,6 +81,7 @@ def build_qa_pairs(text: str) -> List[Dict[str, str]]:
         question = f"What does the text explain about {topic}?"
         pairs.append({"question": question, "answer": answer, "context": answer})
         i += len(chunk)
+
     return pairs
 
 
@@ -129,7 +104,7 @@ def save_dataset(pairs: Iterable[Dict[str, str]], path: Path) -> None:
             "question": clean_text(pair.get("question", "")),
             "answer": clean_text(pair.get("answer", "")),
         }
-        if "context" in pair:
+        if "context" in pair and pair["context"] is not None:
             item["context"] = clean_text(pair["context"])
         cleaned.append(item)
 
@@ -157,6 +132,7 @@ def save_dataset(pairs: Iterable[Dict[str, str]], path: Path) -> None:
 def split_dataset(
     pairs: List[Dict[str, str]],
     ratios: Tuple[float, float, float] = (0.8, 0.1, 0.1),
+    output_dir: Path | None = None,
 ) -> Tuple[List[Dict[str, str]], List[Dict[str, str]], List[Dict[str, str]]]:
     """Split ``pairs`` into train, validation, and test sets and save them."""
 
@@ -177,12 +153,138 @@ def split_dataset(
     val_pairs = shuffled[train_end:val_end]
     test_pairs = shuffled[val_end:]
 
-    SPLITS_DIR.mkdir(parents=True, exist_ok=True)
-    save_dataset(train_pairs, SPLITS_DIR / "train.jsonl")
-    save_dataset(val_pairs, SPLITS_DIR / "val.jsonl")
-    save_dataset(test_pairs, SPLITS_DIR / "test.jsonl")
+    target_dir = output_dir or SPLITS_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    save_dataset(train_pairs, target_dir / "train.jsonl")
+    save_dataset(val_pairs, target_dir / "val.jsonl")
+    save_dataset(test_pairs, target_dir / "test.jsonl")
 
     return train_pairs, val_pairs, test_pairs
+
+
+def _load_jsonl(path: Path) -> List[Dict[str, str]]:
+    """Load a JSON Lines file into memory."""
+
+    with path.open("r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _write_jsonl(records: Iterable[Dict[str, str]], path: Path) -> None:
+    """Write an iterable of dictionaries to ``path`` in JSON Lines format."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _parse_topics(args: argparse.Namespace) -> List[str]:
+    """Resolve topics from command line arguments."""
+
+    topics: List[str] = []
+    if getattr(args, "topics_file", None):
+        with Path(args.topics_file).open("r", encoding="utf-8") as f:
+            topics.extend(line.strip() for line in f if line.strip())
+    if getattr(args, "topics", None):
+        topics.extend(args.topics)
+    if not topics:
+        topics = list(DEFAULT_TOPICS)
+    return topics
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Create the argument parser for the data pipeline CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser(
+        "fetch", help="Download reference articles and store them as JSON Lines"
+    )
+    fetch_parser.add_argument(
+        "--output",
+        type=Path,
+        default=RAW_DIR / "articles.jsonl",
+        help="Path where the raw articles JSONL file should be written.",
+    )
+    fetch_parser.add_argument(
+        "--topics",
+        nargs="*",
+        help="Optional list of topics to fetch. If omitted a default list is used.",
+    )
+    fetch_parser.add_argument(
+        "--topics-file",
+        type=Path,
+        help="Read topics from a text file (one topic per line).",
+    )
+
+    generate_parser = subparsers.add_parser(
+        "generate", help="Build question/answer pairs from raw articles"
+    )
+    generate_parser.add_argument(
+        "--input",
+        type=Path,
+        default=RAW_DIR / "articles.jsonl",
+        help="JSONL file produced by the fetch command.",
+    )
+    generate_parser.add_argument(
+        "--output",
+        type=Path,
+        default=PROCESSED_DIR / "qa_pairs.jsonl",
+        help="Where to store the generated question/answer pairs.",
+    )
+
+    split_parser = subparsers.add_parser(
+        "split", help="Create train/validation/test splits from Q&A pairs"
+    )
+    split_parser.add_argument(
+        "--input",
+        type=Path,
+        default=PROCESSED_DIR / "qa_pairs.jsonl",
+        help="JSONL file with question/answer pairs.",
+    )
+    split_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=SPLITS_DIR,
+        help="Directory where split files should be stored.",
+    )
+    split_parser.add_argument("--train-size", type=float, default=0.8)
+    split_parser.add_argument("--val-size", type=float, default=0.1)
+    split_parser.add_argument("--test-size", type=float, default=0.1)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry-point for the command line interface."""
+
+    args = parse_args(argv)
+
+    if args.command == "fetch":
+        topics = _parse_topics(args)
+        articles = fetch_articles(topics)
+        _write_jsonl(articles, args.output)
+        return 0
+
+    if args.command == "generate":
+        articles = _load_jsonl(args.input)
+        pairs: List[Dict[str, str]] = []
+        for article in articles:
+            text = article.get("content") or article.get("text") or ""
+            if not text:
+                continue
+            pairs.extend(build_qa_pairs(text))
+        save_dataset(pairs, args.output)
+        return 0
+
+    if args.command == "split":
+        ratios = (args.train_size, args.val_size, args.test_size)
+        pairs = _load_jsonl(args.input)
+        split_dataset(pairs, ratios, output_dir=args.output_dir)
+        return 0
+
+    raise ValueError(f"Unhandled command: {args.command}")
 
 
 __all__ = [
@@ -191,4 +293,11 @@ __all__ = [
     "clean_text",
     "save_dataset",
     "split_dataset",
+    "parse_args",
+    "main",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- refactor `src/data_pipeline.py` into a cohesive module with a working CLI for the fetch/generate/split stages
- add sensible default topics, JSONL helpers, and configurable split output directories

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68cddf277338832685fd64220454a3d3