### PR TITLE
Add Route53 IAM policy guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,32 @@ MiniLLM focuses on straightforward factual domains such as astronomy, human anat
    pip install -r requirements.txt
    ```
 
+## AWS IAM Policy
+
+If you are running MiniLLM in an AWS environment that needs to read or update
+Route53 hosted zones, attach the following IAM policy to the role or user that
+executes the deployment scripts:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Route53ReadAccess",
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHostedZones",
+        "route53:ListHostedZonesByName",
+        "route53:GetHostedZone",
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
 ## Repository Structure
 ```
 mini_llm/


### PR DESCRIPTION
## Summary
- document the Route53 IAM policy required for managing hosted zones
- provide the JSON policy snippet for quick reference in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc3c089a4c83268f8861e5b7c42108